### PR TITLE
Add extra HTTP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 **/*.rs.bk
+/repos
+/output

--- a/public/_rustinfra_config.json
+++ b/public/_rustinfra_config.json
@@ -1,0 +1,9 @@
+{
+    "headers": {
+        "Strict-Transport-Security": "max-age=63072000",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin"
+    }
+}

--- a/public/_rustinfra_config.json
+++ b/public/_rustinfra_config.json
@@ -4,6 +4,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "X-XSS-Protection": "1; mode=block",
-        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin"
+        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'; style-src 'self'; img-src 'self'; font-src 'self'"
     }
 }


### PR DESCRIPTION
I already configured the Lambda@Edge on the AWS side. All the headers except the CSP are good, and the CSP *should* be fine, but I don't have a practical way to test it locally. If it causes problems we can either revert that commit or just fix it.

r? @Mark-Simulacrum 
fixes #4 