### PR TITLE
Remove index.html from URLs

### DIFF
--- a/src/site.rs
+++ b/src/site.rs
@@ -90,14 +90,14 @@ fn index(
     let mut releases = Vec::new();
     releases.push(Release {
         name: "All time".into(),
-        url: "/rust/all-time/index.html".into(),
+        url: "/rust/all-time/".into(),
         people: all_time.iter().count(),
         commits: all_time.iter().map(|(_, count)| count).sum(),
     });
     for (version, stats) in by_version.iter().rev() {
         releases.push(Release {
             name: version.name.clone(),
-            url: format!("/rust/{}/index.html", version.version),
+            url: format!("/rust/{}/", version.version),
             people: stats.iter().count(),
             commits: stats.iter().map(|(_, count)| count).sum(),
         });

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -8,7 +8,7 @@
     <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
         <p>
             Rust is a community project and is very thankful for the many community
-            contributions it receives. <a href="/about/index.html">See this page for more
+            contributions it receives. <a href="/about/">See this page for more
             information</a>.
         </p>
 


### PR DESCRIPTION
Now that the redirects are fixed we can safely remove `index.html` from all the links.

r? @Mark-Simulacrum 