### PR TITLE
Discount merge commits and collapse rollup commits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,9 +197,12 @@ fn build_author_map(
     for oid in walker {
         let oid = oid?;
         let commit = repo.find_commit(oid)?;
-        let commit_author = Author::new(commit.author());
-        let author = mailmap.canonicalize(&commit_author);
-        author_map.add(author, oid);
+        // Commits with more than one parent are merge commits and should not be counted.
+        if commit.parents().count() <= 1 {
+            let commit_author = Author::new(commit.author());
+            let author = mailmap.canonicalize(&commit_author);
+            author_map.add(author, oid);
+        }
     }
     Ok(author_map)
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/thanks/issues/12.

Merge commits are now not counted, unless they're part of a rollup, in which case the entire rollup is counted as a single commit. This means @bors is no longer counted, and rollups aren't disproportionately counted. Manual merges in non-rust-lang/rust repositories are also discounted, as they tend to correspond simply to reviews, which aren't counted in other repositories.