### PR TITLE
Fix the thing.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -355,6 +355,18 @@ fn build_author_map_(
     to: &str,
 ) -> Result<AuthorMap, Box<dyn std::error::Error>> {
     let mut walker = repo.revwalk()?;
+
+    if repo.revparse_single(to).is_err() {
+        // If a commit is not found, try fetching it.
+        git(&[
+            "--git-dir",
+            repo.path().to_str().unwrap(),
+            "fetch",
+            "origin",
+            to,
+        ])?;
+    }
+
     if from == "" {
         let to = repo.revparse_single(to)?.peel_to_commit()?.id();
         walker.push(to)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ fn parse_bors_reviewer(
             .map(|r| r.trim_end_matches('`'))
             .map(|r| r.trim())
             .filter(|r| !r.is_empty())
+            .filter(|r| *r != "<try>")
             .inspect(|r| {
                 if !r
                     .chars()


### PR DESCRIPTION
The [ci has been failing](https://github.com/rust-lang/thanks/actions) for about a month. Turns out this was cause by two problems, which this PR fixes:

1. There's a commit with `r=<try>` in the history of `rust-lang/rust`, because of https://github.com/rust-lang/homu/issues/47. That caused an error, because `<` and `>` are not acceptable in usernames.

2. At some point in time the rustfmt submodule refers to commit 939e164c29f92bdbffdb156fa3d53aabbe9a2e0b. That commit is not included under any tag or branch in the rustfmt repo. The ugly workaround is to run `git fetch origin <id>` when a commit is missing.