### PR TITLE
include blog link in navbar

### DIFF
--- a/templates/container.hbs
+++ b/templates/container.hbs
@@ -40,6 +40,7 @@
             <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/tools">Tools</a></li>
             <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/governance">Governance</a></li>
             <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/community">Community</a></li>
+            <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://blog.rust-lang.org/">Blog</a></li>
         </ul>
     </nav>
     {{~> content}}


### PR DESCRIPTION
The navbars look so similar across the various pages and sites on subdomains that I was a bit disoriented at first when I was on the Thanks site and wanted to navigate over to the Blog.

I realize the absence of certain items on both the Thanks and Blog sites may have been done intentionally, but IMO it'd be helpful to have consistency across these too so that, for example, folks that navigate from the main page to the Blog could get to the Playground without having to first go back to the main page.

Understand what I'm suggesting would entail changes to a couple different sites/repos, but figured I'd start here.

Certainly feel free to close if the current structure is intentional and the proposed change is undesirable