### PR TITLE
Change the order of contributors with the same number of contributions to alphabetical order

### DIFF
--- a/src/site.rs
+++ b/src/site.rs
@@ -150,7 +150,7 @@ fn author_map_to_scores(map: &AuthorMap) -> Vec<Entry> {
             commits: commits,
         })
         .collect::<Vec<_>>();
-    scores.sort_by_key(|e| std::cmp::Reverse((e.commits, e.author.clone())));
+    scores.sort_by_key(|e| (std::cmp::Reverse(e.commits), e.author.clone()));
     let mut last_rank = 1;
     let mut ranked_at_current = 0;
     let mut last_commits = usize::max_value();


### PR DESCRIPTION
This PR changes the sort order of contributors with the same number of contributions to alphabetical order.

Currently, contributors with the same number of contributions are sorted in reverse alphabetical order. Although it is just a matter of taste and not essential, I think that alphabetical order is more intuitive.

Many thanks!
