### PR TITLE
Eliminate GHA warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup update stable
+          rustup override set stable
 
       - name: Build static website
         run: cargo run --release


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>