### PR TITLE
Don't panic for non-alphanumeric reviewer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -321,12 +321,11 @@ fn parse_bors_reviewer(
             .filter(|r| !r.is_empty())
             .filter(|r| *r != "<try>")
             .inspect(|r| {
-                if !r
-                    .chars()
-                    .all(|c| c.is_alphabetic() || c.is_digit(10) || c == '-' || c == '_')
-                {
-                    panic!(
-                        "to_author for {} contained non-alphabetic characters: {:?}",
+                if !r.chars().all(|c| {
+                    c.is_alphabetic() || c.is_digit(10) || c == '-' || c == '_' || c == '='
+                }) {
+                    eprintln!(
+                        "warning: to_author for {} contained non-alphabetic characters: {:?}",
                         commit.id(),
                         r
                     );


### PR DESCRIPTION
This fixes a panic due to a commit with a typoed username (`r=compiler=errors`) that contains non-alphanumeric characters. Homu only splits on whitespace for reviewer names, and doesn't really care about the form of the name. This changes it so that instead of panicking, it just prints a warning. This should fix CI which is currently failing.
