### PR TITLE
Add support for removing users' names upon request

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use reviewers::Reviewers;
 
 mod config;
 mod error;
+mod removed;
 mod reviewers;
 mod site;
 

--- a/src/removed.rs
+++ b/src/removed.rs
@@ -1,0 +1,35 @@
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+use mailmap::Author;
+
+lazy_static::lazy_static! {
+    static ref REMOVED: HashSet<mailmap::Author> = HashSet::from_iter([
+        Author {
+            name: "Jonas Schievink".to_string(),
+            email: "jonasschievink@gmail.com".to_string()
+        },
+        Author {
+            name: "Jonas Schievink".to_string(),
+            email: "jonas.schievink@ferrous-systems.com".to_string()
+        },
+        Author {
+            name: "Jonas Schievink".to_string(),
+            email: "jonas@schievink.net".to_string()
+        },
+        Author {
+            name: "Jonas Schievink".to_string(),
+            email: "Jonas.Schievink@sony.com".to_string()
+        }
+    ]);
+}
+
+pub(crate) trait Removed {
+    fn is_removed(&self) -> bool;
+}
+
+impl Removed for Author {
+    fn is_removed(&self) -> bool {
+        REMOVED.contains(self)
+    }
+}

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,3 +1,4 @@
+use crate::removed::Removed;
 use crate::{AuthorMap, VersionTag};
 use handlebars::Handlebars;
 use std::collections::BTreeMap;
@@ -146,7 +147,11 @@ fn author_map_to_scores(map: &AuthorMap) -> Vec<Entry> {
         .iter()
         .map(|(author, commits)| Entry {
             rank: 0,
-            author: author.name.clone(),
+            author: if author.is_removed() {
+                "[removed]".to_string()
+            } else {
+                author.name.clone()
+            },
             commits: commits,
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
cc rust-lang/team#1071

I did not do anything about this user having four instances, as that's completely up to the `.mailmap`, which is not included in this repository.

What this PR does is maintains a list of name-email pairs that have been requested to be removed. If it matches, "[removed]" is output instead of the person's name. Per the user's request, that seems to be sufficient. I'm not sure what else _could_ be done, as the history _does_ exist in git.

Note that this does not remove the entry altogether; it merely removes the name from being displayed.