### PR TITLE
Exclude gcc submodule from thanksbot (similar to llvm)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -650,6 +650,7 @@ fn get_submodules(
             "https://github.com/rust-lang/jemalloc.git",
             "https://github.com/rust-lang/compiler-rt.git",
             "https://github.com/rust-lang/hoedown.git",
+            "https://github.com/rust-lang/gcc.git",
         ];
         is_rust
             && !exclude.contains(&s.repository.as_str())


### PR DESCRIPTION
Since we're now treating `gcc` as a submodule (https://github.com/rust-lang/rust/pull/125419) we're now including all gcc changes from all time. I think that's a bit unfair for rust contributors, since while gcc is a cool project, it's not (yet /hj) rust.

I wondered to myself why this wasn't happening for our llvm submodule (which also includes many many commits that are specifically *not* Rust-related), and it turns out we explicitly exclude the llvm submodule in thanksbot. This PR does the same for gcc.