### PR TITLE
ci: upload artifacts only if owner is rust-lang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo run --release
 
       - name: Upload artifact
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.repository_owner == 'rust-lang'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./output


### PR DESCRIPTION
This avoids running this step in forks, which is not necessary.