### PR TITLE
Ignore enzyme submodule

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -638,6 +638,7 @@ fn get_submodules(
             "https://github.com/rust-lang/llvm.git",
             "https://github.com/rust-lang/llvm-project.git",
             "https://github.com/rust-lang/lld.git",
+            "https://github.com/rust-lang/enzyme.git",
             "https://github.com/rust-lang-nursery/clang.git",
             "https://github.com/rust-lang-nursery/lldb.git",
             "https://github.com/rust-lang/libuv.git",


### PR DESCRIPTION
Nothing against [William Moses](https://thanks.rust-lang.org/rust/1.88.0/), but since we don't count LLVM, LLD, GCC and other similar projects, Enzyme should probably also not be counted.