### PR TITLE
mailmap_from_repo(): make `.mailmap` file optional

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,10 @@ fn mailmap_from_repo(repo: &git2::Repository) -> Result<Mailmap, Box<dyn std::er
         .tree()?;
     let file = tree.get_name(".mailmap");
     let file = match file {
-        None => return Mailmap::from_string("".to_string()),
+        None => {
+            eprintln!("No mailmap found");
+            return Mailmap::from_string("".to_string());
+        },
         Some(f) => f
     };
     let file = String::from_utf8(

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,13 +438,16 @@ fn build_author_map_(
 }
 
 fn mailmap_from_repo(repo: &git2::Repository) -> Result<Mailmap, Box<dyn std::error::Error>> {
+    let tree = repo.revparse_single("HEAD")?
+        .peel_to_commit()?
+        .tree()?;
+    let file = tree.get_name(".mailmap");
+    let file = match file {
+        None => return Mailmap::from_string("".to_string()),
+        Some(f) => f
+    };
     let file = String::from_utf8(
-        repo.revparse_single("HEAD")?
-            .peel_to_commit()?
-            .tree()?
-            .get_name(".mailmap")
-            .unwrap()
-            .to_object(&repo)?
+        file.to_object(&repo)?
             .peel_to_blob()?
             .content()
             .into(),


### PR DESCRIPTION
If not present, treat the same as an empty file