### PR TITLE
Determine branch name for nightly from the repository head

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -504,6 +504,16 @@ fn generate_thanks() -> Result<BTreeMap<VersionTag, AuthorMap>, Box<dyn std::err
         .version
         .clone();
 
+    // The nightly branch is the default one, fall back to "main" if it cannot
+    // be read
+    let nightly_branch = match repo.head() {
+        Ok(reference) => match reference.shorthand() {
+            Some(name) => name.to_string(),
+            None => "main".to_string(),
+        },
+        Err(_) => "main".to_string(),
+    };
+
     versions.push(VersionTag {
         name: String::from("Beta"),
         version: {
@@ -528,7 +538,7 @@ fn generate_thanks() -> Result<BTreeMap<VersionTag, AuthorMap>, Box<dyn std::err
             last.minor += 2;
             last
         },
-        raw_tag: String::from("main"),
+        raw_tag: nightly_branch,
         commit: repo
             .revparse_single("HEAD")
             .unwrap()


### PR DESCRIPTION
Instead of hard-coding the name to be "main". Continue to use "main" as a fallback if the head cannot be retrieved or does not have a shorthand representation.