### PR TITLE
feat: add datapoints from rustup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -558,20 +558,23 @@ fn up_to_release(
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Product {
     Rust,
+    Rustup,
 }
 
 impl Product {
-    const ALL: [Self; 1] = [Self::Rust];
+    const ALL: [Self; 2] = [Self::Rust, Self::Rustup];
 
     fn name(&self) -> &str {
         match self {
             Self::Rust => "Rust",
+            Self::Rustup => "Rustup",
         }
     }
 
     fn repo(&self) -> &str {
         match self {
             Self::Rust => "https://github.com/rust-lang/rust.git",
+            Self::Rustup => "https://github.com/rust-lang/rustup.git",
         }
     }
 
@@ -619,6 +622,22 @@ impl Product {
                     in_progress: true,
                 },
             ],
+            Self::Rustup => vec![VersionTag {
+                name: String::from("Rustup Nightly"),
+                version: {
+                    let mut last = last_full_stable.clone();
+                    last.minor += 1;
+                    last
+                },
+                raw_tag: String::from("main"),
+                commit: repo
+                    .revparse_single("HEAD")
+                    .unwrap()
+                    .peel_to_commit()
+                    .unwrap()
+                    .id(),
+                in_progress: true,
+            }],
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,37 +242,6 @@ impl fmt::Debug for VersionTag {
     }
 }
 
-fn get_versions(repo: &Repository) -> Result<Vec<VersionTag>, Box<dyn std::error::Error>> {
-    let tags = repo
-        .tag_names(None)?
-        .into_iter()
-        .flatten()
-        .map(|v| v.to_owned())
-        .collect::<Vec<_>>();
-    let mut versions = tags
-        .iter()
-        .filter_map(|tag| {
-            Version::parse(tag)
-                .or_else(|_| Version::parse(&format!("{}.0", tag)))
-                .ok()
-                .map(|v| VersionTag {
-                    name: format!("Rust {}", v),
-                    version: v,
-                    raw_tag: tag.clone(),
-                    commit: repo
-                        .revparse_single(tag)
-                        .unwrap()
-                        .peel_to_commit()
-                        .unwrap()
-                        .id(),
-                    in_progress: false,
-                })
-        })
-        .collect::<Vec<_>>();
-    versions.sort();
-    Ok(versions)
-}
-
 /// Identify the co-authors, if any, of a commit
 ///
 /// Co-authors are determined based on the commit message having lines starting
@@ -586,98 +555,172 @@ fn up_to_release(
     Ok(author_map)
 }
 
-fn generate_thanks() -> Result<BTreeMap<VersionTag, AuthorMap>, Box<dyn std::error::Error>> {
-    let path = update_repo("https://github.com/rust-lang/rust.git")?;
-    let repo = git2::Repository::open(&path)?;
-    let mailmap = mailmap_from_repo(&repo)?;
-    let reviewers = Reviewers::new()?;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Product {
+    Rust,
+}
 
-    let mut versions = get_versions(&repo)?;
-    let last_full_stable = versions
-        .iter()
-        .rfind(|v| v.raw_tag.ends_with(".0"))
-        .unwrap()
-        .version
-        .clone();
+impl Product {
+    const ALL: [Self; 1] = [Self::Rust];
 
-    versions.push(VersionTag {
-        name: String::from("Beta"),
-        version: {
-            let mut last = last_full_stable.clone();
-            last.minor += 1;
-            last
-        },
-        raw_tag: String::from("beta"),
-        commit: repo
-            .revparse_single("beta")
-            .unwrap()
-            .peel_to_commit()
-            .unwrap()
-            .id(),
-        in_progress: true,
-    });
-    versions.push(VersionTag {
-        name: String::from("Nightly"),
-        version: {
-            // main is plus 1 minor versions off of beta, which we just pushed
-            let mut last = last_full_stable.clone();
-            last.minor += 2;
-            last
-        },
-        raw_tag: String::from("main"),
-        commit: repo
-            .revparse_single("HEAD")
-            .unwrap()
-            .peel_to_commit()
-            .unwrap()
-            .id(),
-        in_progress: true,
-    });
-
-    let mut version_map = BTreeMap::new();
-
-    let mut cache = HashMap::new();
-
-    for (idx, version) in versions.iter().enumerate() {
-        let previous = if let Some(v) = idx.checked_sub(1).map(|idx| &versions[idx]) {
-            v
-        } else {
-            let author_map = build_author_map(&repo, &reviewers, &mailmap, "", &version.raw_tag)?;
-            version_map.insert(version.clone(), author_map);
-            continue;
-        };
-
-        eprintln!("Processing {:?} to {:?}", previous, version);
-
-        cache.insert(
-            version,
-            up_to_release(&repo, &reviewers, &mailmap, version)?,
-        );
-        let previous = match cache.remove(&previous) {
-            Some(v) => v,
-            None => up_to_release(&repo, &reviewers, &mailmap, previous)?,
-        };
-        let current = cache.get(&version).unwrap();
-
-        // Remove commits reachable from the previous release.
-        let only_current = current.difference(&previous);
-        version_map.insert(version.clone(), only_current);
+    fn name(&self) -> &str {
+        match self {
+            Self::Rust => "Rust",
+        }
     }
 
-    Ok(version_map)
+    fn repo(&self) -> &str {
+        match self {
+            Self::Rust => "https://github.com/rust-lang/rust.git",
+        }
+    }
+
+    fn dummy_versions(&self, repo: &Repository, versions: &[VersionTag]) -> Vec<VersionTag> {
+        let last_full_stable = versions
+            .iter()
+            .rfind(|v| v.raw_tag.ends_with(".0"))
+            .unwrap()
+            .version
+            .clone();
+
+        match self {
+            Self::Rust => vec![
+                VersionTag {
+                    name: String::from("Beta"),
+                    version: {
+                        let mut last = last_full_stable.clone();
+                        last.minor += 1;
+                        last
+                    },
+                    raw_tag: String::from("beta"),
+                    commit: repo
+                        .revparse_single("beta")
+                        .unwrap()
+                        .peel_to_commit()
+                        .unwrap()
+                        .id(),
+                    in_progress: true,
+                },
+                VersionTag {
+                    name: String::from("Nightly"),
+                    version: {
+                        // main is plus 1 minor versions off of beta, which we just pushed
+                        let mut last = last_full_stable.clone();
+                        last.minor += 2;
+                        last
+                    },
+                    raw_tag: String::from("main"),
+                    commit: repo
+                        .revparse_single("HEAD")
+                        .unwrap()
+                        .peel_to_commit()
+                        .unwrap()
+                        .id(),
+                    in_progress: true,
+                },
+            ],
+        }
+    }
+
+    fn get_versions(
+        &self,
+        repo: &Repository,
+    ) -> Result<Vec<VersionTag>, Box<dyn std::error::Error>> {
+        let tags = repo
+            .tag_names(None)?
+            .into_iter()
+            .flatten()
+            .map(|v| v.to_owned())
+            .collect::<Vec<_>>();
+        let mut versions = tags
+            .iter()
+            .filter_map(|tag| {
+                Version::parse(tag)
+                    .or_else(|_| Version::parse(&format!("{}.0", tag)))
+                    .ok()
+                    .map(|v| VersionTag {
+                        name: format!("{name} {v}", name = self.name()),
+                        version: v,
+                        raw_tag: tag.clone(),
+                        commit: repo
+                            .revparse_single(tag)
+                            .unwrap()
+                            .peel_to_commit()
+                            .unwrap()
+                            .id(),
+                        in_progress: false,
+                    })
+            })
+            .collect::<Vec<_>>();
+        versions.sort();
+        Ok(versions)
+    }
+
+    fn generate_thanks(
+        &self,
+    ) -> Result<BTreeMap<VersionTag, AuthorMap>, Box<dyn std::error::Error>> {
+        let path = update_repo(self.repo())?;
+        let repo = git2::Repository::open(&path)?;
+        let mailmap = mailmap_from_repo(&repo)?;
+        let reviewers = Reviewers::new()?;
+
+        let mut versions = self.get_versions(&repo)?;
+        versions.extend(self.dummy_versions(&repo, &versions));
+
+        let mut version_map = BTreeMap::new();
+
+        let mut cache = HashMap::new();
+
+        for (idx, version) in versions.iter().enumerate() {
+            let previous = if let Some(v) = idx.checked_sub(1).map(|idx| &versions[idx]) {
+                v
+            } else {
+                let author_map =
+                    build_author_map(&repo, &reviewers, &mailmap, "", &version.raw_tag)?;
+                version_map.insert(version.clone(), author_map);
+                continue;
+            };
+
+            eprintln!("Processing {} {:?} to {:?}", self.name(), previous, version);
+
+            cache.insert(
+                version,
+                up_to_release(&repo, &reviewers, &mailmap, version)?,
+            );
+            let previous = match cache.remove(&previous) {
+                Some(v) => v,
+                None => up_to_release(&repo, &reviewers, &mailmap, previous)?,
+            };
+            let current = cache.get(&version).unwrap();
+
+            // Remove commits reachable from the previous release.
+            let only_current = current.difference(&previous);
+            version_map.insert(version.clone(), only_current);
+        }
+
+        Ok(version_map)
+    }
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let by_version = generate_thanks()?;
+    let products = Product::ALL;
 
-    let mut all_time = by_version.values().next().unwrap().clone();
-    for map in by_version.values().skip(1) {
-        all_time.extend(map.clone());
+    let mut by_version = Vec::with_capacity(products.len());
+    for product in &products {
+        let thanks = product.generate_thanks()?;
+        by_version.push(thanks);
     }
 
-    site::render(by_version, all_time)?;
+    let all_time =
+        by_version
+            .iter()
+            .flat_map(|m| m.values())
+            .fold(AuthorMap::new(), |mut acc, map| {
+                acc.extend(map.clone());
+                acc
+            });
 
-    Ok(())
+    site::render(&products, &by_version, &all_time)
 }
 
 fn main() {

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,4 +1,4 @@
-use crate::{AuthorMap, VersionTag};
+use crate::{AuthorMap, Product, VersionTag};
 use handlebars::Handlebars;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -6,15 +6,20 @@ use std::path::Path;
 use unicase::UniCase;
 
 pub fn render(
-    by_version: BTreeMap<VersionTag, AuthorMap>,
-    all_time_map: AuthorMap,
+    products: &[Product],
+    by_version: &[BTreeMap<VersionTag, AuthorMap>],
+    all_time_map: &AuthorMap,
 ) -> Result<(), Box<dyn std::error::Error>> {
     copy_public()?;
-    index(&all_time_map, &by_version)?;
     about()?;
-    releases(&by_version, &all_time_map)?;
 
-    Ok(())
+    let mut index_releases = vec![];
+    for (product, by_version) in products.iter().zip(by_version) {
+        index_releases.extend(product.index_releases(all_time_map, by_version)?);
+        product.releases(by_version, all_time_map)?;
+    }
+
+    index(index_releases)
 }
 
 #[derive(serde::Serialize)]
@@ -70,40 +75,22 @@ fn copy_public() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn index(
-    all_time: &AuthorMap,
-    by_version: &BTreeMap<VersionTag, AuthorMap>,
-) -> Result<(), Box<dyn std::error::Error>> {
+#[derive(serde::Serialize)]
+pub struct Release {
+    name: String,
+    url: String,
+    people: usize,
+    commits: usize,
+}
+
+pub fn index(releases: Vec<Release>) -> Result<(), Box<dyn std::error::Error>> {
     #[derive(serde::Serialize)]
-    struct Release {
-        name: String,
-        url: String,
-        people: usize,
-        commits: usize,
-    }
-    #[derive(serde::Serialize)]
-    struct Index {
+    pub struct Index {
         common: CommonData,
         releases: Vec<Release>,
     }
+
     let hb = hb()?;
-
-    let mut releases = Vec::new();
-    releases.push(Release {
-        name: "All time".into(),
-        url: "/rust/all-time/".into(),
-        people: all_time.iter().count(),
-        commits: all_time.iter().map(|(_, count)| count).sum(),
-    });
-    for (version, stats) in by_version.iter().rev() {
-        releases.push(Release {
-            name: version.name.clone(),
-            url: format!("/rust/{}/", version.version),
-            people: stats.iter().count(),
-            commits: stats.iter().map(|(_, count)| count).sum(),
-        });
-    }
-
     let res = hb.render(
         "index",
         &Index {
@@ -114,6 +101,36 @@ fn index(
 
     fs::write("output/index.html", res)?;
     Ok(())
+}
+
+impl Product {
+    fn index_releases(
+        &self,
+        all_time: &AuthorMap,
+        by_version: &BTreeMap<VersionTag, AuthorMap>,
+    ) -> Result<Vec<Release>, Box<dyn std::error::Error>> {
+        let mut releases = Vec::new();
+        if self == &Self::Rust {
+            releases.push(Release {
+                name: "All time".into(),
+                url: "/rust/all-time/".into(),
+                people: all_time.iter().count(),
+                commits: all_time.iter().map(|(_, count)| count).sum(),
+            });
+        }
+
+        let product = self.name();
+        let product_lower = product.to_lowercase();
+        for (version, stats) in by_version.iter().rev() {
+            releases.push(Release {
+                name: version.name.clone(),
+                url: format!("/{product_lower}/{}/", version.version),
+                people: stats.iter().count(),
+                commits: stats.iter().map(|(_, count)| count).sum(),
+            });
+        }
+        Ok(releases)
+    }
 }
 
 fn about() -> Result<(), Box<dyn std::error::Error>> {
@@ -212,53 +229,60 @@ fn deduplicate_scores(entries: Vec<Entry>) -> Vec<Entry> {
         .collect()
 }
 
-fn releases(
-    by_version: &BTreeMap<VersionTag, AuthorMap>,
-    all_time: &AuthorMap,
-) -> Result<(), Box<dyn std::error::Error>> {
-    #[derive(serde::Serialize)]
-    struct Release {
-        common: CommonData,
-        release_title: String,
-        release: String,
-        count: usize,
-        scores: Vec<Entry>,
-        in_progress: bool,
+impl Product {
+    fn releases(
+        &self,
+        by_version: &BTreeMap<VersionTag, AuthorMap>,
+        all_time: &AuthorMap,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        #[derive(serde::Serialize)]
+        struct Release {
+            common: CommonData,
+            release_title: String,
+            release: String,
+            count: usize,
+            scores: Vec<Entry>,
+            in_progress: bool,
+        }
+        let hb = hb()?;
+        let scores = author_map_to_scores(all_time);
+
+        let product = self.name();
+        if self == &Self::Rust {
+            let res = hb.render(
+                "stats",
+                &Release {
+                    common: CommonData::new("All-time Rust Contributors".into()),
+                    release_title: String::from("All-time"),
+                    release: String::from("all of Rust"),
+                    count: scores.len(),
+                    scores,
+                    in_progress: true,
+                },
+            )?;
+
+            create_dir("output/rust/all-time")?;
+            fs::write("output/rust/all-time/index.html", res)?;
+        }
+
+        let product_lower = product.to_lowercase();
+        for (version, map) in by_version {
+            let scores = author_map_to_scores(map);
+            let res = hb.render(
+                "stats",
+                &Release {
+                    common: CommonData::new(format!("{product} {version} Contributors")),
+                    release_title: version.name.clone(),
+                    release: version.to_string(),
+                    count: scores.len(),
+                    scores,
+                    in_progress: version.in_progress,
+                },
+            )?;
+
+            create_dir(format!("output/{product_lower}/{version}"))?;
+            fs::write(format!("output/{product_lower}/{version}/index.html"), res)?;
+        }
+        Ok(())
     }
-    let hb = hb()?;
-    let scores = author_map_to_scores(all_time);
-
-    let res = hb.render(
-        "stats",
-        &Release {
-            common: CommonData::new("All-time Rust Contributors".into()),
-            release_title: String::from("All-time"),
-            release: String::from("all of Rust"),
-            count: scores.len(),
-            scores,
-            in_progress: true,
-        },
-    )?;
-
-    create_dir("output/rust/all-time")?;
-    fs::write("output/rust/all-time/index.html", res)?;
-
-    for (version, map) in by_version {
-        let scores = author_map_to_scores(map);
-        let res = hb.render(
-            "stats",
-            &Release {
-                common: CommonData::new(format!("Rust {} Contributors", version)),
-                release_title: version.name.clone(),
-                release: version.to_string(),
-                count: scores.len(),
-                scores,
-                in_progress: version.in_progress,
-            },
-        )?;
-
-        create_dir(format!("output/rust/{}", version))?;
-        fs::write(format!("output/rust/{}/index.html", version), res)?;
-    }
-    Ok(())
 }


### PR DESCRIPTION
Related to #77, as this PR also introduces a new extension point to add projects outside of `rust-lang/rust` and is not limited to `rust-lang/rustup`.

This first version simply puts all rustup releases below all Rust releases:

<img width="706" height="360" alt="image" src="https://github.com/user-attachments/assets/0bb75b37-167f-4c01-a3ce-592fbf546cec" />

... and the rest of the project seems to be working out of the box from here:

<img width="814" height="545" alt="image" src="https://github.com/user-attachments/assets/5343c657-f500-480a-a888-e1ddb1942387" />

