### PR TITLE
Add reviewer entry for camelid

### DIFF
--- a/src/reviewers.rs
+++ b/src/reviewers.rs
@@ -67,6 +67,7 @@ impl Reviewers {
         insert("brson", a("Brian Anderson", "andersrb@gmail.com"));
         insert("bugadani", a("Dániel Buga", "bugadani@gmail.com"));
         insert("c410-f3r", a("Caio", "c410.f3r@gmail.com"));
+        insert("camelid", a("Noah Lev", "camelidcamel@gmail.com"));
         insert("catamorphism", a("Tim Chevalier", "chevalier@alum.wellesley.edu"));
         insert("cdirkx", a("Christiaan Dirkx", "christiaan@dirkx.email"));
         insert("chris", a("Chris Morgan", "me@chrismorgan.info"));


### PR DESCRIPTION
Ever since I encrypted my email in the team database, I've had two entries for my name on Rust Thanks. This should fix that issue by canonicalizing my reviewer email to be the same as my committer email.