### PR TITLE
Sort submodules to fix non-deterministic commit iteration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -834,6 +834,9 @@ fn get_submodules(
             && !exclude.contains(&repo_name.as_str())
             && !exclude.contains(&&*format!("{}.git", repo_name))
     });
+
+    // Sort the submodules to ensure deterministic commit iteration order
+    submodules.sort_by(|a, b| a.repository.cmp(&b.repository));
     Ok(submodules)
 }
 


### PR DESCRIPTION
Frederick Zhang has commits under `frederick888@tsundere.moe` in Clippy in `1.22.0`, but under `Frederick888@Tsundere.moe` in Cargo. We were iterating submodules in a non-deterministic order, which caused the e-mail normalization to pick one of them essentially by random.

By sorting the submodules, we ensure that the output will stay deterministic. If we add more submodules in the future, the order could in theory change, but at that point we can just re-bless tests.
